### PR TITLE
feat: added ros-time with simulated time to library

### DIFF
--- a/crates/rosty/src/lib.rs
+++ b/crates/rosty/src/lib.rs
@@ -9,6 +9,7 @@ extern crate tracing;
 
 mod node;
 mod rosxmlrpc;
+mod simtime;
 mod tcpros;
 mod time;
 
@@ -19,6 +20,7 @@ use crate::tcpros::Message;
 use node::{Node, NodeArgs, Param};
 
 use serde::Deserialize;
+use std::time::SystemTime;
 pub use time::{Duration, Time};
 
 /// The instance that represents this node.
@@ -39,6 +41,11 @@ pub async fn init_with_args(args: NodeArgs, capture_sigint: bool) -> Result<(), 
     }
 
     let node = Node::new(args).await?;
+
+    // Initialize the use of simtime
+    if node.is_using_sim_time() {
+        node.init_sim_time().await?;
+    }
 
     if capture_sigint {
         let shutdown_sender = node.shutdown_token.clone();
@@ -69,6 +76,27 @@ macro_rules! node {
     };
 }
 
+/// Returns 'now' as a Time object
+/// # Situations
+/// * If the node is run normally the current time is returned. Ros calls this WallTime.
+///   This can panic if the SystemTime cannot be retrieved
+/// * If the node is run in simulated time i.e. `/use_sim_time` is true. Then the simulated
+///   time is returned. In this case a panic could occur if the `/clock` topic has not
+///   been published
+pub fn now() -> Duration {
+    if !node!().is_using_sim_time() {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Could not get the SystemTime")
+            .into()
+    } else {
+        node!()
+            .get_last_sim_clock()
+            .expect("No /clock message received")
+            .into()
+    }
+}
+
 /// Returns the URI of this node
 pub fn uri() -> String {
     node!().uri().to_owned()
@@ -87,6 +115,11 @@ pub fn hostname() -> String {
 /// Returns the bind address of the node
 pub fn bind_address() -> String {
     node!().bind_address().to_owned()
+}
+
+/// Returns wether the node is running with simualated time
+pub fn is_using_sim_time() -> bool {
+    node!().is_using_sim_time()
 }
 
 pub async fn topics() -> Response<Vec<Topic>> {

--- a/crates/rosty/src/lib.rs
+++ b/crates/rosty/src/lib.rs
@@ -42,11 +42,6 @@ pub async fn init_with_args(args: NodeArgs, capture_sigint: bool) -> Result<(), 
 
     let node = Node::new(args).await?;
 
-    // Initialize the use of simtime
-    if node.is_using_sim_time() {
-        node.init_sim_time().await?;
-    }
-
     if capture_sigint {
         let shutdown_sender = node.shutdown_token.clone();
         ctrlc::set_handler(move || {

--- a/crates/rosty/src/node.rs
+++ b/crates/rosty/src/node.rs
@@ -138,12 +138,8 @@ impl Node {
         let param = Param::new("/use_sim_time", master.clone());
 
         // Try to get the sim_time, and open a topic if we are waiting for it
-        let sim_time = if param.exists().await? {
-            if param.get::<bool>().await? {
-                Some(SimTime::new())
-            } else {
-                None
-            }
+        let sim_time = if param.exists().await? && param.get::<bool>().await? {
+            Some(SimTime::new())
         } else {
             None
         };

--- a/crates/rosty/src/node.rs
+++ b/crates/rosty/src/node.rs
@@ -144,7 +144,7 @@ impl Node {
             None
         };
 
-        Ok(Node {
+        let node = Node {
             slave: Arc::new(slave),
             master,
             hostname: args.hostname.to_owned(),
@@ -153,18 +153,14 @@ impl Node {
             result: result_mutex,
             shutdown_token,
             sim_time,
-        })
-    }
+        };
 
-    /// Initializes the receiving of the simulated time
-    /// This function panics if the '/use_sim_time'
-    /// parameter was not found
-    pub async fn init_sim_time(&self) -> Result<(), SubscriptionError> {
-        self.sim_time
-            .as_ref()
-            .expect("SimTime was None, this means the /use_sim_time topic was not found")
-            .init(self)
-            .await
+        // Initialize sim time if we are using it
+        if node.sim_time.is_some() {
+            node.sim_time.as_ref().unwrap().init(&node).await?;
+        }
+
+        Ok(node)
     }
 
     /// Returns the URI of this node

--- a/crates/rosty/src/node.rs
+++ b/crates/rosty/src/node.rs
@@ -156,8 +156,8 @@ impl Node {
         };
 
         // Initialize sim time if we are using it
-        if node.sim_time.is_some() {
-            node.sim_time.as_ref().unwrap().init(&node).await?;
+        if let Some(sim_time) = &node.sim_time {
+            sim_time.init(&node).await?;
         }
 
         Ok(node)

--- a/crates/rosty/src/simtime.rs
+++ b/crates/rosty/src/simtime.rs
@@ -1,0 +1,44 @@
+use crate::node::{Node, SubscriptionError};
+
+use crate::Duration;
+use futures::StreamExt;
+use rosty_msg::rosgraph_msgs::Clock;
+use std::sync::{Arc, RwLock};
+
+#[derive(Debug)]
+/// The Simulated Time struct, holds a reference to the last message received on the clock interface
+pub struct SimTime {
+    last_clock_msg: Arc<RwLock<Option<Clock>>>,
+}
+
+impl SimTime {
+    pub fn new() -> Self {
+        let last_clock_msg = Arc::new(RwLock::new(None));
+        SimTime { last_clock_msg }
+    }
+
+    /// Initialize to the subscribing of simulated time
+    pub async fn init(&self, node: &Node) -> Result<(), SubscriptionError> {
+        let last_clock_msg_cloned = self.last_clock_msg.clone();
+        let future = node
+            .subscribe::<rosty_msg::rosgraph_msgs::Clock>("/clock", 1)
+            .await?
+            .for_each(move |(_, clock_msg)| {
+                let local = last_clock_msg_cloned.clone();
+                // Set the last variable as a member
+                async move {
+                    let mut guard = local.write().unwrap();
+                    *guard = Some(clock_msg);
+                }
+            });
+
+        tokio::spawn(future);
+        Ok(())
+    }
+
+    /// Returns the last received time
+    pub fn duration(&self) -> Option<Duration> {
+        let message = self.last_clock_msg.read().unwrap().clone();
+        message.and_then(|message| Some(message.into()))
+    }
+}

--- a/crates/rosty/src/time.rs
+++ b/crates/rosty/src/time.rs
@@ -1,3 +1,4 @@
+use rosty_msg::rosgraph_msgs::Clock;
 use serde_derive::{Deserialize, Serialize};
 use std::cmp;
 use std::ops;
@@ -166,9 +167,19 @@ impl From<time::Duration> for Duration {
     }
 }
 
+impl From<Clock> for Duration {
+    fn from(clock: Clock) -> Self {
+        Duration {
+            sec: clock.clock.sec as i32,
+            nsec: clock.clock.nsec as i32,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Duration, Time};
+    use rosty_msg::rosgraph_msgs::Clock;
     use std::time;
 
     #[test]
@@ -179,6 +190,17 @@ mod tests {
         let time = Duration::from_nanos(123456789987654321);
         assert_eq!(time.sec, 123456789);
         assert_eq!(time.nsec, 987654321);
+    }
+
+    #[test]
+    fn from_clock_works() {
+        let mut clock = Clock::default();
+        clock.clock.sec = 100;
+        clock.clock.nsec = 1000;
+
+        let duration: Duration = clock.into();
+        assert_eq!(duration.sec, 100);
+        assert_eq!(duration.nsec, 1000);
     }
 
     #[test]

--- a/crates/rosty/tests/no_sim_time.rs
+++ b/crates/rosty/tests/no_sim_time.rs
@@ -1,0 +1,12 @@
+pub mod util;
+
+#[test]
+fn no_sim_time() {
+    util::run_with_node(async {
+        // Don't use simtime normally
+        assert!(!rosty::is_using_sim_time());
+
+        // Check if we are getting a time from the now function
+        assert!(rosty::now().seconds() > 0.0,)
+    });
+}

--- a/crates/rosty/tests/parameters.rs
+++ b/crates/rosty/tests/parameters.rs
@@ -1,4 +1,4 @@
-mod util;
+pub mod util;
 
 #[test]
 fn test_parameter_api() {
@@ -27,6 +27,12 @@ fn test_parameter_api() {
 
         // And it should be changed
         assert_eq!(param.get::<i32>().await.unwrap(), 10);
+
+        // Change it to a boolean
+        // param.set(&true).await.unwrap();
+
+        // And this should return true
+        // assert!(param.get::<bool>().await.unwrap());
 
         // Delete this parameter
         param.delete().await.unwrap();

--- a/crates/rosty/tests/shutdown_token.rs
+++ b/crates/rosty/tests/shutdown_token.rs
@@ -1,4 +1,4 @@
-mod util;
+pub mod util;
 use futures::{future::maybe_done, pin_mut};
 
 #[test]

--- a/crates/rosty/tests/subscribe.rs
+++ b/crates/rosty/tests/subscribe.rs
@@ -1,4 +1,4 @@
-mod util;
+pub mod util;
 use futures::StreamExt;
 use tokio::process::Command;
 

--- a/crates/rosty/tests/topic.rs
+++ b/crates/rosty/tests/topic.rs
@@ -1,4 +1,4 @@
-mod util;
+pub mod util;
 use rosty::Topic;
 
 #[test]

--- a/crates/rosty/tests/use_sim_time.rs
+++ b/crates/rosty/tests/use_sim_time.rs
@@ -1,0 +1,31 @@
+pub mod util;
+use tokio::time;
+
+#[test]
+fn use_sim_time() {
+    util::run_with_node_simtime(async {
+        // Check if the parameter is set and equals true
+        let param = rosty::param("/use_sim_time");
+        assert!(
+            param.exists().await.unwrap(),
+            "/use_sim_time does not exist"
+        );
+        assert!(
+            param.get::<bool>().await.unwrap(),
+            "/use_sim_time is not true"
+        );
+
+        // In that case is_using_sim_time should also be true
+        assert!(rosty::is_using_sim_time());
+
+        let mut child = util::publish_clock().unwrap();
+        // Wait for the message to be published
+        tokio::time::delay_for(time::Duration::from_millis(500)).await;
+
+        // Check if we get the value published
+        let duration = rosty::now();
+        assert_eq!(duration.sec, 100);
+        assert_eq!(duration.nsec, 1000);
+        child.kill().expect("Could not stop clock publisher");
+    })
+}

--- a/crates/rosty/tests/util/mod.rs
+++ b/crates/rosty/tests/util/mod.rs
@@ -102,7 +102,7 @@ pub fn run_with_node_simtime(generator: impl Future<Output = ()>) {
         // Use the sim time
         set_use_sim_time().expect("Cannot set the simtime parameter");
         // Wait for the param to actually be set
-        tokio::time::delay_for(time::Duration::from_millis(100)).await;
+        tokio::time::delay_for(time::Duration::from_millis(1000)).await;
         rosty::init("test").await.unwrap();
         generator.await;
     })


### PR DESCRIPTION
Closes #7 

This implements the simulated ROS-time for Rosty, with corresponding tests. There is a `now` function in the public API that either gives the current time since epoch or the simulated clock time depending on if the parameter `/use_sim_time` is set. Note, that this API is a bit of a departure from classical Ros libraries, that implement this method on Time.

My reasons are because it is actually a function with side-effects and that can potentially panic, that it is nicer to place this directly in the public API. Because, putting it in the Time struct, or in our case, the Duration struct, would imply that it would only use the System time. Which is less likely to fail.

I've also made all the test utility functions public, otherwise, warnings would be issued during compilation.

